### PR TITLE
Added GCLD

### DIFF
--- a/Security-Certification-Roadmap8.html
+++ b/Security-Certification-Roadmap8.html
@@ -1774,9 +1774,11 @@
                     <a class="iamitem1" href="https://trailhead.salesforce.com/help?article=Salesforce-Certified-Identity-and-Access-Management-Designer-Exam-Guide" tooltiptext="SalesForce Certified Identity and Access Management Designer
     $400 exam" tabindex="0" target="_blank">SF CIAMD</a>
                     <div class="spacer"></div>
-                    <div class="spacer"></div>
                     <a class="engineeritem1" href="https://aws.amazon.com/certification/certified-solutions-architect-associate/" tooltiptext="Amazon Web Services Certified Solutions Architect - Associate
     $150 exam" tabindex="0" target="_blank" >AWS SAA</a>
+                    <a class="engineeritem1" href="https://www.giac.org/certifications/cloud-security-essentials-gcld/" tooltiptext="GIAC Cloud Security Essentials
+    $849 exam
+    SANS course recommended" tabindex="0" target="_blank" >GCLD</a>
                     <a class="engineeritem1" href="https://www.exin.com/certifications/ccc-professional-cloud-service-manager-exam" tooltiptext="EXIN Professional Cloud Service Manager
     $315 exam" tabindex="0" target="_blank" >EXIN PCSerM</a>
                     <a class="engineeritem1" href="https://www.mosse-institute.com/certifications/mdso-certified-devsecops-engineer.html" tooltiptext="Mosse Institute Certified DevSecOps Engineer

--- a/Security-Certification-Roadmap8.html
+++ b/Security-Certification-Roadmap8.html
@@ -1773,12 +1773,10 @@
                     <div class="spacer"></div>
                     <a class="iamitem1" href="https://trailhead.salesforce.com/help?article=Salesforce-Certified-Identity-and-Access-Management-Designer-Exam-Guide" tooltiptext="SalesForce Certified Identity and Access Management Designer
     $400 exam" tabindex="0" target="_blank">SF CIAMD</a>
-                    <div class="spacer"></div>
+                    <a class="engineeritem1" href="https://www.giac.org/certifications/cloud-security-essentials-gcld/" tooltiptext="GIAC Cloud Security Essentials
+    $849 exam SANS course recommended" tabindex="0" target="_blank" >GCLD</a>
                     <a class="engineeritem1" href="https://aws.amazon.com/certification/certified-solutions-architect-associate/" tooltiptext="Amazon Web Services Certified Solutions Architect - Associate
     $150 exam" tabindex="0" target="_blank" >AWS SAA</a>
-                    <a class="engineeritem1" href="https://www.giac.org/certifications/cloud-security-essentials-gcld/" tooltiptext="GIAC Cloud Security Essentials
-    $849 exam
-    SANS course recommended" tabindex="0" target="_blank" >GCLD</a>
                     <a class="engineeritem1" href="https://www.exin.com/certifications/ccc-professional-cloud-service-manager-exam" tooltiptext="EXIN Professional Cloud Service Manager
     $315 exam" tabindex="0" target="_blank" >EXIN PCSerM</a>
                     <a class="engineeritem1" href="https://www.mosse-institute.com/certifications/mdso-certified-devsecops-engineer.html" tooltiptext="Mosse Institute Certified DevSecOps Engineer


### PR DESCRIPTION
As course author of SANS SEC488: Cloud Security Essentials, I would like to add the associated exam (GIAC GCLD) to this chart.

https://www.sans.org/cyber-security-courses/cloud-security-essentials/

Thanks for what you are doing! This chart is very valuable to those in the industry that do not know where to focus their efforts.