### PR TITLE
Fix Splunk Enterprise Security Certified Administrator info

### DIFF
--- a/Security-Certification-Roadmap8.html
+++ b/Security-Certification-Roadmap8.html
@@ -1826,8 +1826,8 @@
     $2,700 course + exam
     Course required" tabindex="0" target="_blank" >ISA CRAS</a>
                     <a class="engineeritem1" href="https://www.splunk.com/en_us/training/certification-track/splunk-es-certified-admin.html" tooltiptext="Splunk Enterprise Security Certified Administrator
-    $4625 exams + 3 courses
-    Branded courses required" tabindex="0" target="_blank" >Splunk ECSA</a>
+    $130 exam
+    Branded course recommended" tabindex="0" target="_blank" >SPLK-<wbr/>3001</a>
                     <div class="spacer"></div>
                     <div class="spacer"></div>
                     <a class="mgmtitem2" href="https://www.bcs.org/get-qualified/certifications-for-professionals/information-security-and-ccp-scheme-certifications/bcs-practitioner-certificate-in-information-assurance-architecture/" tooltiptext="BCS Practitioner Certificate in Information Assurance Architecture


### PR DESCRIPTION
The official exam code is SPLK-3001 and an attempt costs $130. 
It does not require any previous certifications or courses, although the certification track flowchart recommends "Administering Splunk Enterprise Security" ($1500 course).