### PR TITLE
Fix misspelling on Azure Solutions Architect Expert, should be AZ-305 instead of AZ-500.

### DIFF
--- a/Security-Certification-Roadmap8.html
+++ b/Security-Certification-Roadmap8.html
@@ -1160,7 +1160,7 @@
                     <div class="spacer5"></div>
                     <div class="spacer"></div>
                     <a class="engineeritem1" href="https://docs.microsoft.com/en-us/learn/certifications/azure-solutions-architect?wt.mc_id=learningredirect_certs-web-wwl" tooltiptext="Microsoft Azure Solutions Architect Expert
-    $330 exam" tabindex="0" target="_blank" >AZ-500</a>
+    $330 exam" tabindex="0" target="_blank" >AZ-305</a>
                     <div class="spacer"></div>
                     <a class="engineeritem1" href="https://www.vmware.com/education-services/certification/vcap-nv-deploy.html" tooltiptext="VMware Certified Implementation Expert in Network Virtualization
     $900 two exams" tabindex="0" target="_blank" >VCIX NV</a>


### PR DESCRIPTION
Fix misspelling on Azure Solutions Architect Expert, should be AZ-305 instead of AZ-500.