### PR TITLE
Fix CREST links and names

### DIFF
--- a/Security-Certification-Roadmap8.html
+++ b/Security-Certification-Roadmap8.html
@@ -931,9 +931,6 @@
                     <div class="spacer5"></div>
                     <div class="spacer"></div>
                     <div class="spacer"></div>
-                    <a class="engineeritem1" href="https://www.crest-approved.org/examination/technical-security-architecture/index.html" tooltiptext="CREST Registered Technical Security Architect
-    $2,300 two exams
-    In person in the UK" tabindex="0" target="_blank" >CREST CRTSA</a>
                     <div class="spacer"></div>
                     <div class="spacer"></div>
                     <a class="mgmtitem2" href="https://www.axelos.com/certifications/itil-certifications/itil-master" tooltiptext="ITIL Master
@@ -1086,7 +1083,7 @@
                     <div class="spacer"></div>
                     <div class="spacer"></div>
                     <div class="spacer"></div>
-                    <a class="redopsitem2" href="https://crest-approved.org/examination/certified-simulated-attack-manager/index.html" tooltipright="CREST Certified Simulated Attack Manager
+                    <a class="redopsitem2" href="https://www.crest-approved.org/certification-careers/crest-certifications/crest-certified-simulated-attack-manager" tooltipright="CREST Certified Simulated Attack Manager
     $2,499 2 exams" tabindex="0" target="_blank" >CREST CSAM</a>
                     <div class="spacer"></div>
                     <!-- Row 8 -->
@@ -1150,7 +1147,7 @@
                     <a class="redopsitem1" href="https://elearnsecurity.com/product/ewptxv2-certification/" tooltiptext="eLearnSecurity Web Application Penetration Tester eXtreme
     $400 exam
     $2000 training" tabindex="0" target="_blank" >eWPTX</a>
-                    <a class="redopsitem1" href="https://crest-approved.org/examination/certified-simulated-attack-specialist/index.html" tooltiptext="CREST Certified Simulated Attack Specialist
+                    <a class="redopsitem1" href="https://www.crest-approved.org/certification-careers/crest-certifications/crest-certified-simulated-attack-specialist" tooltiptext="CREST Certified Simulated Attack Specialist
     $2,520 2 exams &amp; lab" tabindex="0" target="_blank" >CREST CCSAS</a>
                     <div class="spacer"></div>
                     <div class="spacer"></div>
@@ -1207,8 +1204,8 @@
   100% practical. No expiry." tabindex="0" target="_blank">MRT</a>
                     <div class="spacer"></div>
                     <div class="spacer"></div>
-                    <a class="redopsitem1" href="https://crest-approved.org/examination/certified-infrastructure-tester/index.html" tooltiptext="CREST Certified Infrastructure Tester
-    $2,520 exam &amp; lab" tabindex="0" target="_blank" >CREST CCT</a>
+                    <a class="redopsitem1" href="https://www.crest-approved.org/certification-careers/crest-certifications/crest-certified-infrastructure-tester" tooltiptext="CREST Certified Infrastructure Tester
+    $2,520 exam &amp; lab" tabindex="0" target="_blank" >CREST CCT INF</a>
                     <div class="spacer"></div>
                     <div class="spacer"></div>
                     <div class="spacer"></div>
@@ -1259,7 +1256,7 @@
                     <div class="spacer"></div>
                     <a class="redopsitem1" href="https://www.seco-institute.org/certifications/ethical-hacking-track/leader/" tooltiptext="SECO Certified Ethical Hacker Leader
     Application" tabindex="0" target="_blank" >S-CEHL</a>
-                    <a class="redopsitem1" href="https://crest-approved.org/examination/registered-tester/index.html" tooltiptext="CREST Registered Penetration Tester
+                    <a class="redopsitem1" href="https://www.crest-approved.org/certification-careers/crest-certifications/crest-registered-penetration-tester" tooltiptext="CREST Registered Penetration Tester
     $612 exam" tabindex="0" target="_blank" >CREST CRT</a>
                     <a class="redopsitem1" href="https://training.zeropointsecurity.co.uk/courses/red-team-ops-ii" tooltiptext="Zero Point Security Red Team Operator II
     $121 lab" tabindex="0" target="_blank" >CRTO II</a>
@@ -1358,8 +1355,8 @@
                     <a class="redopsitem1" href="https://www.pentesteracademy.com/redteamlab" tooltiptext="Pentester Academy Certified Red Teaming Expert
     $300-700 Lab Access
     Exam included" tabindex="0" target="_blank" >PA CRTE</a>
-                    <a class="redopsitem1" href="https://crest-approved.org/examination/crest-certified-threat-intelligence-manager/index.html" tooltiptext="CREST Certified Threat Intelligence Manager
-    $2,480 3 exams" tabindex="0" target="_blank" >CREST CTIM</a>
+                    <a class="redopsitem1" href="https://www.crest-approved.org/certification-careers/crest-certifications/crest-certified-threat-intelligence-manager" tooltiptext="CREST Certified Threat Intelligence Manager
+    $2,480 3 exams" tabindex="0" target="_blank" >CREST CCTIM</a>
                     <div class="spacer"></div>
                     <div class="spacer"></div>
                     <a class="redopsitem2" href="https://www.offensive-security.com/pwk-oscp/" tooltipright="Offensive Security Certified Professional
@@ -1579,11 +1576,11 @@
     $485 written exam" tabindex="0" target="_blank" >CCE</a>
                     <a class="blueopsitem1" href="https://www.mile2.com/master-certifications/" tooltiptext="Mile2 Certified Master Digital Forensic Investigator
     Complete C)SP, C)DFE, C)NFE and C)CSA ($2200)" tabindex="0" target="_blank" >CM)DFI</a>
-                    <a class="blueopsitem1" href="https://crest-approved.org/examination/registered-intrusion-analyst/index.html" tooltiptext="CREST Registered Intrusion Analyst
+                    <a class="blueopsitem1" href="https://www.crest-approved.org/certification-careers/crest-certifications/crest-registered-intrusion-analyst" tooltiptext="CREST Registered Intrusion Analyst
     $612 exam &amp; lab" tabindex="0" target="_blank" >CREST CRIA</a>
                     <div class="spacer"></div>
-                    <a class="blueopsitem1" href="https://crest-approved.org/examination/crest-registered-threat-intelligence-analyst/index.html" tooltiptext="CREST Registered Threat Intelligence Analyst
-    $615 2 exams" tabindex="0" target="_blank" >CREST RTIA</a>
+                    <a class="blueopsitem1" href="https://www.crest-approved.org/certification-careers/crest-certifications/crest-registered-threat-intelligence-analyst" tooltiptext="CREST Registered Threat Intelligence Analyst
+    $615 2 exams" tabindex="0" target="_blank" >CREST CRTIA</a>
                     <a class="redopsitem1" href="https://www.pentesteracademy.com/activedirectorylab" tooltiptext="Pentester Academy Certified Red Team Professional
     $250-500 Lab Access
     Exam included" tabindex="0" target="_blank" >PA CRTP</a>
@@ -1596,8 +1593,6 @@
                     <a class="redopsitem1" href="https://gaqm.org/certifications/information_systems_security/certified_penetration_tester_cpt" tooltiptext="GAQM Certified Penetration Tester
     $128 exam" tabindex="0" target="_blank" >GCPT</a>
                     <div class="spacer"></div>
-                    <a class="redopsitem1" href="https://crest-approved.org/examination/malware-reverse-engineer/index.html" tooltipright="CREST Certified Malware Reverse Engineer
-    $2,499 2 exams &amp; lab" tabindex="0" target="_blank" >CREST CMRE</a>
                     <a class="redopsitem1" href="https://www.elearnsecurity.com/certification/ecxd" tooltipright="eLearnSecurity Certified eXploit Developer
     $400 lab" tabindex="0" target="_blank" >eCXD</a>
                     <!-- Row 16 -->
@@ -1676,8 +1671,8 @@
     100% practical. No expiry." tabindex="0" target="_blank">MPT</a>
                     <a class="redopsitem1" href="https://www.eccouncil.org/programs/certified-penetration-testing-professional-cpent/" tooltiptext="EC Council Certified Penetration Testing Professional
     $999 exam" tabindex="0" target="_blank" >CPENT</a>
-                    <a class="redopsitem1" href="https://crest-approved.org/examination/certified-web-application-tester/index.html" tooltiptext="CREST Certified Web Application Tester
-    $2,520 exam &amp; lab" tabindex="0" target="_blank" >CREST CWAT</a>
+                    <a class="redopsitem1" href="https://www.crest-approved.org/certification-careers/crest-certifications/crest-certified-web-application-tester/" tooltiptext="CREST Certified Web Application Tester
+    $2,520 exam &amp; lab" tabindex="0" target="_blank" >CREST CCT APP</a>
                     <a class="redopsitem1" href="https://www.giac.org/certification/enterprise-vulnerability-assessor-geva" tooltiptext="GIAC Enterprise Vulnerability Assessor
     $1999 exam
     SANS course recommended" tabindex="0" target="_blank" >GEVA</a>
@@ -1695,9 +1690,9 @@
                     <div class="spacer"></div>
                     <a class="mgmtitem25" href="https://www.learnpython.org/" tooltiptext="Learning a programming language is valuable to any IT professionals career.
     Recommendations: Python, Ruby, C++" tabindex="0" target="_blank" >Programming Language</a>
-                    <a class="blueopsitem1" href="https://crest-approved.org/examination/host-intrusion-analyst/index.html" tooltiptext="CREST Certified Host intrustion Analyst
+                    <a class="blueopsitem1" href="https://www.crest-approved.org/certification-careers/crest-certifications/crest-certified-host-intrusion-analyst" tooltiptext="CREST Certified Host intrustion Analyst
     $2,481 exam &amp; essay
-    Hands on exam in UK" tabindex="0" target="_blank" >CREST CHIA</a>
+    Hands on exam in UK" tabindex="0" target="_blank" >CREST CCHIA</a>
                     <a class="blueopsitem1" href="https://www.opentext.com/products-and-solutions/services/training-and-learning-services/encase-training/examiner-certification" tooltiptext="OpenText EnCase Certified Examiner
     $200 two exams" tabindex="0" target="_blank" >EnCE</a>
                     <a class="blueopsitem1" href="https://accessdata.com/training/computer-forensics-certification" tooltiptext="AccessData Certified Examiner
@@ -1894,9 +1889,9 @@
     $400 exam" tabindex="0" target="_blank" >NSE 4</a>
                     <a class="networkitem1" href="https://www.cwnp.com/certifications/cwsp" tooltipleft="CWNP Certified Wireless Security Professional
     $325 exam" tabindex="0" target="_blank" >CWSP</a>
-                    <a class="networkitem1" href="https://crest-approved.org/examination/certified-network-intrusion-analyst/index.html" tooltiptext="CREST Certified Network Intrusion Analyst
+                    <a class="networkitem1" href="https://www.crest-approved.org/certification-careers/crest-certifications/crest-certified-network-intrusion-analyst" tooltiptext="CREST Certified Network Intrusion Analyst
     $2,481 exam &amp; essay
-    Hands on exam in UK" tabindex="0" target="_blank">CREST CNIA</a>
+    Hands on exam in UK" tabindex="0" target="_blank">CREST CCNIA</a>
                     <div class="spacer"></div>
                      <a class="iamitem1" href="https://www.identitymanagementinstitute.org/cige/" tooltiptext="IMI Certified Identity Governance Expert
     $395 exam" target="_blank">CIGE</a>
@@ -1975,7 +1970,7 @@
                     <a class="redopsitem1" href="https://www.isecom.org/certification.html" tooltiptext="ISECOM Certified Hacker Analyst Trainer
     $100 annual sub
     Unknown exam price" tabindex="0" target="_blank" >CHAT</a>
-                    <a class="redopsitem1" href="https://crest-approved.org/examination/practitioner-security-analyst/index.html" tooltiptext="CREST Practitioner Security Analyst
+                    <a class="redopsitem1" href="https://www.crest-approved.org/certification-careers/crest-certifications/crest-practitioner-security-analyst" tooltiptext="CREST Practitioner Security Analyst
     $425 exam" tabindex="0" target="_blank" >CREST CPSA</a>
                     <div class="spacer"></div>
                     <div class="spacer"></div>
@@ -2111,7 +2106,7 @@
     Course required" tabindex="0" target="_blank" >DV MoS</a>
                     <a class="redopsitem1" style="font-size:0.5vmax;" href="https://www.comptia.org/certifications/pentest" tooltiptext="CompTIA Pentest+
     $349 exam" tabindex="0" target="_blank" >Pentest+</a>
-                    <a class="redopsitem1" href="https://crest-approved.org/examination/certified-simulated-attack-specialist/index.html" tooltipright="CREST Certified Simulated Attack Specialist
+                    <a class="redopsitem1" href="https://www.crest-approved.org/certification-careers/crest-certifications/crest-certified-simulated-attack-specialist" tooltipright="CREST Certified Simulated Attack Specialist
     $2,520 2 exams &amp; lab" tabindex="0" target="_blank" >CREST CSAS</a>
                     <a class="redopsitem1" href="https://www.eccouncil.org/programs/ec-council-certified-encryption-specialist-eces/" tooltipright="EC Council Certified Encryption Specialist
     $249 exam" tabindex="0" target="_blank" >ECES</a>
@@ -2150,11 +2145,11 @@
                     <a class="blueopsitem1" href="https://www.isaca.org/credentialing/cybersecurity/csx-forensics-analysis-certificate" tooltiptext="ISACA Cybersecurity Packet Analysis Certificate
     $250 exam" tabindex="0" target="_blank" >CSX-PA</a>
                     <div class="spacer"></div>
-                    <a class="blueopsitem1" href="https://crest-approved.org/examination/crest-practitioner-intrusion-analyst/index.html" tooltiptext="CREST Practitioner Intrusion Analyst
+                    <a class="blueopsitem1" href="https://www.crest-approved.org/certification-careers/crest-certifications/crest-practitioner-intrusion-analyst" tooltiptext="CREST Practitioner Intrusion Analyst
     $425 exam" tabindex="0" target="_blank" >CREST CPIA</a>
                     <a class="blueopsitem1" href="https://www.mosse-institute.com/certifications/mese-certified-enterprise-security-engineer.html" tooltiptext="Mosse Institute Enterprise Security Engineer
     $450 exam" tabindex="0" target="_blank" >MESE</a>
-                    <a class="blueopsitem1" href="https://crest-approved.org/examination/crest-practitioner-threat-intelligence-analyst/index.html" tooltiptext="CREST Practitioner Threat Intelligence Analyst
+                    <a class="blueopsitem1" href="https://www.crest-approved.org/certification-careers/crest-certifications/crest-practitioner-threat-intelligence-analyst/" tooltiptext="CREST Practitioner Threat Intelligence Analyst
     $425 exam" tabindex="0" target="_blank" >CREST CPTIA</a>
                     <div class="spacer"></div>
                     <a class="redopsitem1" href="https://www.mosse-institute.com/certifications/mcpt-cloud-penetration-tester.html" tooltiptext="Mosse Institute Cloud Penetration Tester


### PR DESCRIPTION
- CREST links were all broken. Updated with new URLs
- Consistent naming of CREST certs. Some certs were list without an extra C at the beginning while others were.  Changed all to match the way CREST lists them
- Removed some certs that no longer seem to exist on CREST site