### PR TITLE
remove certifications that are no longer available (PA CRTP, PA CRTE, LFCE)

### DIFF
--- a/Security-Certification-Roadmap8.html
+++ b/Security-Certification-Roadmap8.html
@@ -1354,9 +1354,7 @@
     SANS course recommended" tabindex="0" target="_blank" >GCED</a>
                     <a class="blueopsitem1" href="https://www.mosse-institute.com/certifications/mcpe-certified-cyber-protection-expert.html" tooltiptext="Mosse Institute Certified Cyber Protection Expert
     $800 exam" tabindex="0" target="_blank" >MCPE</a>
-                    <a class="redopsitem1" href="https://www.pentesteracademy.com/redteamlab" tooltiptext="Pentester Academy Certified Red Teaming Expert
-    $300-700 Lab Access
-    Exam included" tabindex="0" target="_blank" >PA CRTE</a>
+                    <div class="spacer"></div>
                     <a class="redopsitem1" href="https://crest-approved.org/examination/crest-certified-threat-intelligence-manager/index.html" tooltiptext="CREST Certified Threat Intelligence Manager
     $2,480 3 exams" tabindex="0" target="_blank" >CREST CTIM</a>
                     <div class="spacer"></div>
@@ -1583,9 +1581,7 @@
                     <div class="spacer"></div>
                     <a class="blueopsitem1" href="https://crest-approved.org/examination/crest-registered-threat-intelligence-analyst/index.html" tooltiptext="CREST Registered Threat Intelligence Analyst
     $615 2 exams" tabindex="0" target="_blank" >CREST RTIA</a>
-                    <a class="redopsitem1" href="https://www.pentesteracademy.com/activedirectorylab" tooltiptext="Pentester Academy Certified Red Team Professional
-    $250-500 Lab Access
-    Exam included" tabindex="0" target="_blank" >PA CRTP</a>
+                    <div class="spacer"></div>
                     <a class="redopsitem1" href="https://www.giac.org/certification/gwapt" tooltiptext="GIAC Web Application Penetration Tester
     $949 exam
     SANS course recommended" tabindex="0" target="_blank" >GWAPT</a>

--- a/Security-Certification-Roadmap8.html
+++ b/Security-Certification-Roadmap8.html
@@ -1024,8 +1024,7 @@
                     <a class="engineeritem1" href="https://www.vmware.com/education-services/certification/vcap-dcv-design.html" tooltiptext="VMware Certified Implementation Expert in Datacenter Virtualization
     $900 two exams" tabindex="0" target="_blank" >VCIX DCV</a>
                     <div class="spacer"></div>
-                    <a class="engineeritem1" href="https://training.linuxfoundation.org/certification/linux-foundation-certified-engineer-lfce/" tooltiptext="Linux Foundation Certified Engineer
-    $300 exam" tabindex="0" target="_blank" >LFCE</a>
+                    <div class="spacer"></div>
                     <a class="engineeritem1" href="https://www.sans.org/course/ics-cyber-security-in-depth" tooltiptext="SANS ICS612: ICS Cybersecurity in-Depth (Certification Pending)
     ~$949 exam
     SANS course encouraged" tabindex="0" target="_blank" >GIAC ICS612</a>

--- a/Security-Certification-Roadmap9.html
+++ b/Security-Certification-Roadmap9.html
@@ -1353,9 +1353,7 @@ $949 exam
 SANS course recommended" tabindex="0" target="_blank" >GCED</a>
             <a class="blueopsitem1" href="https://www.mosse-institute.com/certifications/mcpe-certified-cyber-protection-expert.html" tooltiptext="Mosse Institute Certified Cyber Protection Expert
 $800 exam" tabindex="0" target="_blank" >MCPE</a>
-            <a class="redopsitem1" href="https://www.pentesteracademy.com/redteamlab" tooltiptext="Pentester Academy Certified Red Teaming Expert
-$300-700 Lab Access
-Exam included" tabindex="0" target="_blank" >PA CRTE</a>
+            <div class="spacer"></div>
             <a class="redopsitem1" href="https://crest-approved.org/examination/crest-certified-threat-intelligence-manager/index.html" tooltiptext="CREST Certified Threat Intelligence Manager
 $2,480 3 exams" tabindex="0" target="_blank" >CREST CTIM</a>
             <div class="spacer"></div>
@@ -1582,9 +1580,7 @@ $612 exam &amp; lab" tabindex="0" target="_blank" >CREST CRIA</a>
             <div class="spacer"></div>
             <a class="blueopsitem1" href="https://crest-approved.org/examination/crest-registered-threat-intelligence-analyst/index.html" tooltiptext="CREST Registered Threat Intelligence Analyst
 $615 2 exams" tabindex="0" target="_blank" >CREST RTIA</a>
-            <a class="redopsitem1" href="https://www.pentesteracademy.com/activedirectorylab" tooltiptext="Pentester Academy Certified Red Team Professional
-$250-500 Lab Access
-Exam included" tabindex="0" target="_blank" >PA CRTP</a>
+            <div class="spacer"></div>
             <a class="redopsitem1" href="https://www.giac.org/certification/gwapt" tooltiptext="GIAC Web Application Penetration Tester
 $949 exam
 SANS course recommended" tabindex="0" target="_blank" >GWAPT</a>

--- a/Security-Certification-Roadmap9.html
+++ b/Security-Certification-Roadmap9.html
@@ -1023,8 +1023,7 @@ SANS course recommended" tabindex="0" target="_blank" >GXPN</a>
             <a class="engineeritem1" href="https://www.vmware.com/education-services/certification/vcap-dcv-design.html" tooltiptext="VMware Certified Implementation Expert in Datacenter Virtualization
 $900 two exams" tabindex="0" target="_blank" >VCIX DCV</a>
             <div class="spacer"></div>
-            <a class="engineeritem1" href="https://training.linuxfoundation.org/certification/linux-foundation-certified-engineer-lfce/" tooltiptext="Linux Foundation Certified Engineer
-$300 exam" tabindex="0" target="_blank" >LFCE</a>
+            <div class="spacer"></div>
             <a class="engineeritem1" href="https://www.sans.org/course/ics-cyber-security-in-depth" tooltiptext="SANS ICS612: ICS Cybersecurity in-Depth (Certification Pending)
 ~$949 exam
 SANS course encouraged" tabindex="0" target="_blank" >GIAC ICS612</a>


### PR DESCRIPTION
According to THE LINUX FOUNDATION website this certification is no longer available.
https://training.linuxfoundation.org/LFCECERT-inactive/

According to Penterster Academy website CRTP and CRTE are no longer available
https://www.pentesteracademy.com/activedirectorylab
https://www.pentesteracademy.com/redteamlab 
