### PR TITLE
Add Certified CyberDefender Course

### DIFF
--- a/Security-Certification-Roadmap8.html
+++ b/Security-Certification-Roadmap8.html
@@ -1008,7 +1008,12 @@
                     <div class="spacer"></div>
                     <a class="blueopsitem1" href="https://www.iacis.com/certification/" tooltiptext="IACIS Certified Forensic Computer Examiner
     $750 4 peer reviewed exams" tabindex="0" target="_blank" >CFCE</a>
-                    <div class="spacer5"></div>
+		    <a class="blueopsitem2" href="https://cyberdefenders.org/blue-team-training/courses/certified-cyberdefender-certification/" tooltiptext="Certified CyberDefender
+$800 course
+2 exam attempt included" tabindex="0" target="_blank">CCD</a>
+                    <div class="spacer"></div>
+		    <div class="spacer"></div>
+		    <div class="spacer"></div>
                     <div class="spacer"></div>
                     <div class="spacer"></div>
                     <a class="redopsitem2" href="https://www.giac.org/certification/gxpn" tooltipright="GIAC Exploit Researcher and Advanced Penetration Tester

--- a/Security-Certification-Roadmap9.html
+++ b/Security-Certification-Roadmap9.html
@@ -1006,8 +1006,13 @@ $1388 interview" tabindex="0" target="_blank" >NCSC CCPLP</a>
             <div class="spacer"></div>
             <div class="spacer"></div>
             <a class="blueopsitem1" href="https://www.iacis.com/certification/" tooltiptext="IACIS Certified Forensic Computer Examiner
-$750 4 peer reviewed exams" tabindex="0" target="_blank" >CFCE</a>
-            <div class="spacer5"></div>
+    $750 4 peer reviewed exams" tabindex="0" target="_blank" >CFCE</a>
+            <a class="blueopsitem2" href="https://cyberdefenders.org/blue-team-training/courses/certified-cyberdefender-certification/" tooltiptext="Certified CyberDefender
+$800 course
+2 exam attempt included" tabindex="0" target="_blank">CCD</a>
+            <div class="spacer"></div>
+            <div class="spacer"></div>
+            <div class="spacer"></div>
             <div class="spacer"></div>
             <div class="spacer"></div>
             <a class="redopsitem2" href="https://www.giac.org/certification/gxpn" tooltipright="GIAC Exploit Researcher and Advanced Penetration Tester

--- a/Security-Certification-Roadmap9.html
+++ b/Security-Certification-Roadmap9.html
@@ -1007,9 +1007,8 @@ $1388 interview" tabindex="0" target="_blank" >NCSC CCPLP</a>
             <div class="spacer"></div>
             <a class="blueopsitem1" href="https://www.iacis.com/certification/" tooltiptext="IACIS Certified Forensic Computer Examiner
     $750 4 peer reviewed exams" tabindex="0" target="_blank" >CFCE</a>
-            <a class="blueopsitem2" href="https://cyberdefenders.org/blue-team-training/courses/certified-cyberdefender-certification/" tooltiptext="Certified CyberDefender
-$800 course
-2 exam attempt included" tabindex="0" target="_blank">CCD</a>
+            <div class="spacer"></div>
+            <div class="spacer"></div>
             <div class="spacer"></div>
             <div class="spacer"></div>
             <div class="spacer"></div>
@@ -1787,10 +1786,9 @@ $300 practical exam" tabindex="0" target="_blank" >OSIP</a>
 ~$325 exam" tabindex="0" target="_blank">Cisco COA</a>
             <a class="blueopsitem1" href="https://www.mile2.com/ccsa_outline/" tooltiptext="Mile2 Certified Cybersecurity Analyst
 $550 exam" tabindex="0" target="_blank" >C)CSA</a>
-            <a class="blueopsitem1" href="https://www.eccouncil.org/programs/computer-hacking-forensic-investigator-chfi/" tooltiptext="EC Council Computer Hacking Forensics Investigator
-$650 exam" tabindex="0" target="_blank" >CHFI</a>
-            <a class="blueopsitem1" href="https://www.seco-institute.org/get-trained/cyber-defense-track/threat-analyst-certification/" tooltiptext="SECO Certified Threat Analyst
-$550 exam" tabindex="0" target="_blank" >S-TA</a>
+            <a class="blueopsitem2" href="https://cyberdefenders.org/blue-team-training/courses/certified-cyberdefender-certification/" tooltiptext="Certified CyberDefender
+$800 course
+2 exam attempt included" tabindex="0" target="_blank">CCD</a>
             <a class="blueopsitem1" href="https://www.eccouncil.org/programs/ec-council-certified-incident-handler-ecih/" tooltiptext="EC Council Certified Incident Handler
 $300 exam" tabindex="0" target="_blank" >ECIH</a>
             <a class="redopsitem1" href="https://www.mile2.com/cpSH_outline/" tooltiptext="Mile2 Certified Powershell Hacker
@@ -1871,11 +1869,10 @@ $549 lab" tabindex="0" target="_blank" >CSX-P</a>
             <a class="blueopsitem1" href="https://www.mile2.com/network-forensics-examiner-outline/" tooltiptext="Mile2 Certified Network Forensics Examiner
 $550 exam
 Groups only" tabindex="0" target="_blank" >C)NFE</a>
-            <a class="blueopsitem1" href="https://www.giac.org/certification/open-source-intelligence-gosi" tooltiptext="GIAC Open Source Intelligence
-$949 exam
-SANS course recommended" tabindex="0" target="_blank" >GOSI</a>
-            <a class="blueopsitem1" href="https://www.mile2.com/threat-analyst/" tooltiptext="Mile2 Certified Threat Intelligence Analyst
-$550 exam" tabindex="0" target="_blank" >C)TIA</a>
+            <a class="blueopsitem1" href="https://www.eccouncil.org/programs/computer-hacking-forensic-investigator-chfi/" tooltiptext="EC Council Computer Hacking Forensics Investigator
+$650 exam" tabindex="0" target="_blank" >CHFI</a>
+            <a class="blueopsitem1" href="https://www.seco-institute.org/get-trained/cyber-defense-track/threat-analyst-certification/" tooltiptext="SECO Certified Threat Analyst
+$550 exam" tabindex="0" target="_blank" >S-TA</a>
             <a class="blueopsitem2" href="https://www.offensive-security.com/soc200-osda/" tooltiptext="Offensive Security Defense Analyst
 $2,499 exam
 Learning subscription required" tabindex="0" target="_blank" >OSDA</a>
@@ -1963,9 +1960,11 @@ $49 certification programme
 100% practical. No expiry." tabindex="0" target="_blank">MRCI</a>
     <a class="blueopsitem1" href="https://www.eccouncil.org/programs/disaster-recovery-professional-edrp/" tooltiptext="EC Council Disaster Recovery Professional
 $450 exam" tabindex="0" target="_blank" >EDRP</a>
-            <div class="spacer"></div>
-            <a class="blueopsitem1" href="https://certnexus.com/certification/cybersec-first-responder/" tooltiptext="CertNexus CyberSec First Responder
-$250 exam" tabindex="0" target="_blank" >CFR</a>
+            <a class="blueopsitem1" href="https://www.giac.org/certification/open-source-intelligence-gosi" tooltiptext="GIAC Open Source Intelligence
+$949 exam
+SANS course recommended" tabindex="0" target="_blank" >GOSI</a>
+            <a class="blueopsitem1" href="https://www.mile2.com/threat-analyst/" tooltiptext="Mile2 Certified Threat Intelligence Analyst
+$550 exam" tabindex="0" target="_blank" >C)TIA</a>
             <a class="blueopsitem1" href="https://www.eccouncil.org/programs/certified-threat-intelligence-analyst-ctia/" tooltiptext="EC Council Certified Threat intelligence Analyst
 $450 exam" tabindex="0" target="_blank" >CTIA</a>
             <a class="redopsitem1" href="https://thecyberscheme.org/cyber-scheme-team-member-cstm-exam/" tooltiptext="Cyber Scheme Team Member
@@ -2050,10 +2049,9 @@ $1,700 course exam
 Branded course required" tabindex="0" target="_blank" >CSAE</a>
             <a class="blueopsitem1" href="https://www.asisonline.org/certification/professional-certified-investigator-pci" tooltiptext="ASIS Professional Certified Investigator
 $485 exam" tabindex="0" target="_blank" >ASIS PCI</a>
-            <a class="blueopsitem1" href="https://mitre-engenuity.org/mad/" tooltiptext="Mitre Att&ck Defender Security Operations Center Assessment
-            $299 annual subscription" tabindex="0" target="_blank" >MAD SOCA</a>
-            <a class="blueopsitem1" href="https://mitre-engenuity.org/mad/" tooltiptext="Mitre Att&ck Defender Cyber Threat intelligence
-            $299 annual subscription" tabindex="0" target="_blank" >MAD CTI</a>
+            <div class="spacer"></div>
+            <a class="blueopsitem1" href="https://certnexus.com/certification/cybersec-first-responder/" tooltiptext="CertNexus CyberSec First Responder
+$250 exam" tabindex="0" target="_blank" >CFR</a>
             <a class="redopsitem2" href="https://www.eccouncil.org/programs/certified-ethical-hacker-ceh/" tooltiptext="EC Council Certified Ethical Hacker
 $1,199 exam" tabindex="0" target="_blank" >CEH</a>
     <div class="spacer"></div>
@@ -2102,9 +2100,10 @@ $450 certification programme
 100% practical. No expiry." tabindex="0" target="_blank">MOIS</a>
             <a class="blueopsitem1" href="https://gaqm.org/certifications/information_systems_security/cfa" tooltiptext="GAQM Certified Forensic Analyst
 $128 exam" tabindex="0" target="_blank" >CFA</a>
-            <div class="spacer"></div>
-            <a class="blueopsitem1" href="https://www.eccouncil.org/programs/certified-soc-analyst-csa/" tooltiptext="EC Council Certified SOC Analyst
-$550 exam" tabindex="0" target="_blank" >CSA</a>
+            <a class="blueopsitem1" href="https://mitre-engenuity.org/mad/" tooltiptext="Mitre Att&ck Defender Security Operations Center Assessment
+            $299 annual subscription" tabindex="0" target="_blank" >MAD SOCA</a>
+            <a class="blueopsitem1" href="https://mitre-engenuity.org/mad/" tooltiptext="Mitre Att&ck Defender Cyber Threat intelligence
+            $299 annual subscription" tabindex="0" target="_blank" >MAD CTI</a>
             <a class="blueopsitem2" href="https://www.giac.org/certifications/foundational-cybersecurity-technologies-gfact/" tooltiptext="GIAC Foundational Cybersecurity Technologies
 $949 exam
 SANS course recommended" tabindex="0" target="_blank" >GFACT</a>
@@ -2154,10 +2153,9 @@ $249 exam" tabindex="0" target="_blank" ><b>SSCP</b></a>
             <a class="blueopsitem1" href="https://www.isaca.org/credentialing/cybersecurity/csx-forensics-analysis-certificate" tooltiptext="ISACA Cybersecurity Packet Analysis Certificate
 $250 exam" tabindex="0" target="_blank" >CSX-PA</a>
             <div class="spacer"></div>
-            <a class="blueopsitem1" href="https://crest-approved.org/examination/crest-practitioner-intrusion-analyst/index.html" tooltiptext="CREST Practitioner Intrusion Analyst
-$425 exam" tabindex="0" target="_blank" >CREST CPIA</a>
-            <a class="blueopsitem1" href="https://www.mosse-institute.com/certifications/mese-certified-enterprise-security-engineer.html" tooltiptext="Mosse Institute Enterprise Security Engineer
-$450 exam" tabindex="0" target="_blank" >MESE</a>
+            <div class="spacer"></div>
+            <a class="blueopsitem1" href="https://www.eccouncil.org/programs/certified-soc-analyst-csa/" tooltiptext="EC Council Certified SOC Analyst
+$550 exam" tabindex="0" target="_blank" >CSA</a>
             <a class="blueopsitem1" href="https://crest-approved.org/examination/crest-practitioner-threat-intelligence-analyst/index.html" tooltiptext="CREST Practitioner Threat Intelligence Analyst
 $425 exam" tabindex="0" target="_blank" >CREST CPTIA</a>
             <div class="spacer"></div>
@@ -2203,9 +2201,10 @@ $349 exam" tabindex="0" target="_blank" ><b>Security+</b></a>
 $249 exam" tabindex="0" target="_blank" >ECSS</a>
             <a class="blueopsitem1" href="https://www.mile2.com/cdfe_outline/" tooltiptext="Mile2 Certified Digital Forensics Examiner
 $550 exam" tabindex="0" target="_blank" >C)DFE</a>
-            <div class="spacer"></div>
-            <a class="blueopsitem1" href="https://www.seco-institute.org/get-trained/cyber-defense-track/associate-soc-analyst-certification/" tooltiptext="SECO Associate SOC Analyst
-$480 exam" tabindex="0" target="_blank" >S-SA</a>
+            <a class="blueopsitem1" href="https://crest-approved.org/examination/crest-practitioner-intrusion-analyst/index.html" tooltiptext="CREST Practitioner Intrusion Analyst
+$425 exam" tabindex="0" target="_blank" >CREST CPIA</a>
+            <a class="blueopsitem1" href="https://www.mosse-institute.com/certifications/mese-certified-enterprise-security-engineer.html" tooltiptext="Mosse Institute Enterprise Security Engineer
+$450 exam" tabindex="0" target="_blank" >MESE</a>
             <a class="blueopsitem1" href="https://0xdarkvortex.dev/training-programs/adversary-operations-and-proactive-hunting/" tooltiptext="Dark Vortex Adversary Operations and Proactive Hunting
 $2500 exam
 Course required" tabindex="0" target="_blank" >DV AOPH</a>
@@ -2278,11 +2277,9 @@ Unknown exam cost" tabindex="0" target="_blank" >OPSE</a>
 $768 course exam
 Branded course required" tabindex="0" target="_blank" >CSX-F</a>
             <div class="spacer"></div>
-             <a class="blueopsitem1" href="https://0xdarkvortex.dev/training-programs/malware-incident-and-log-forensics/" tooltiptext="Dark Vortex Malware Incident and Log Foensics
-$2000 exam" tabindex="0" target="_blank" >DV MILF</a>
-            <a class="blueopsitem1" href="https://www.itgovernance.co.uk/shop/product/cyber-incident-response-management-foundation-training-course" tooltiptext="IBITGQ Cyber Incident Response Management Foundation
-$768 course exam
-Branded course required" tabindex="0" target="_blank" >CIRM Fdn</a>
+            <div class="spacer"></div>
+			<a class="blueopsitem1" href="https://www.seco-institute.org/get-trained/cyber-defense-track/associate-soc-analyst-certification/" tooltiptext="SECO Associate SOC Analyst
+$480 exam" tabindex="0" target="_blank" >S-SA</a>
             <div class="spacer"></div>
             <div class="spacer"></div>
             <a class="redopsitem1" href="https://www.exin.com/certifications/exin-ethical-hacking-foundation-exam" tooltiptext="EXIN Ethical Hacking Foundation
@@ -2353,8 +2350,11 @@ $450 exam" tabindex="0" target="_blank">MASE</a>
             <a class="blueopsitem1" href="https://www.mile2.com/csp_outline/" tooltiptext="Mile2 Certified Security Principles
 $550 exam" tabindex="0" target="_blank" >C)SP</a>
             <div class="spacer"></div>
-            <div class="spacer"></div>
-            <div class="spacer"></div>
+            <a class="blueopsitem1" href="https://0xdarkvortex.dev/training-programs/malware-incident-and-log-forensics/" tooltiptext="Dark Vortex Malware Incident and Log Foensics
+$2000 exam" tabindex="0" target="_blank" >DV MILF</a>
+            <a class="blueopsitem1" href="https://www.itgovernance.co.uk/shop/product/cyber-incident-response-management-foundation-training-course" tooltiptext="IBITGQ Cyber Incident Response Management Foundation
+$768 course exam
+Branded course required" tabindex="0" target="_blank" >CIRM Fdn</a>
             <a class="blueopsitem1" href="https://www.eccouncil.org/programs/certified-network-defender-cnd/" tooltiptext="EC Council Certified Network Defender
 $550 exam" tabindex="0" target="_blank" >CND</a>
             <div class="spacer"></div>


### PR DESCRIPTION
Added the CCD exam to the chart for the Certified CyberDefender course. You can find the course and exam details at the following link: [Certified CyberDefender Certification](https://cyberdefenders.org/blue-team-training/courses/certified-cyberdefender-certification/)

Thank you for your valuable contributions! This chart is immensely helpful for industry professionals seeking guidance on where to focus their efforts.