### PR TITLE
Change CAP to CGRC

### DIFF
--- a/Security-Certification-Roadmap8.html
+++ b/Security-Certification-Roadmap8.html
@@ -1328,8 +1328,8 @@
     SANS course recommended" tabindex="0" target="_blank" >GLEG</a>
                     <a class="mgmtitem1" href="https://gaqm.org/certifications/information_systems_security/cissm" tooltiptext="GAQM Certified Information Systems Security Manager
     $170 exam" tabindex="0" target="_blank" >CISSM</a>
-                    <a class="mgmtitem1" href="https://www.isc2.org/Certifications/CAP" tooltiptext="(ISC)2 Certified Authorization Professional
-    $599 exam" tabindex="0" target="_blank" >CAP</a>
+                    <a class="mgmtitem1" href="https://www.isc2.org/Certifications/CGRC" tooltiptext="(ISC)2 Certified in Governance, Risk and Compliance
+    $599 exam" tabindex="0" target="_blank" >CGRC</a>
                     <a class="mgmtitem1" href="https://www.isc2.org/Certifications/HCISPP" tooltiptext="(ISC)2 Healthcare Information Security and Privacy Practitioner
     $599 exam" tabindex="0" target="_blank">HCISPP</a>
                     <a class="mgmtitem3" href="https://www.isaca.org/credentialing/crisc" tooltiptext="ISACA Certified in Risk and Information Systems Control

--- a/Security-Certification-Roadmap9.html
+++ b/Security-Certification-Roadmap9.html
@@ -1327,8 +1327,8 @@ $949 exam
 SANS course recommended" tabindex="0" target="_blank" >GLEG</a>
             <a class="mgmtitem1" href="https://gaqm.org/certifications/information_systems_security/cissm" tooltiptext="GAQM Certified Information Systems Security Manager
 $170 exam" tabindex="0" target="_blank" >CISSM</a>
-            <a class="mgmtitem1" href="https://www.isc2.org/Certifications/CAP" tooltiptext="(ISC)2 Certified Authorization Professional
-$599 exam" tabindex="0" target="_blank" >CAP</a>
+            <a class="mgmtitem1" href="https://www.isc2.org/Certifications/CGRC" tooltiptext="(ISC)2 Certified in Governance, Risk and Compliance
+$599 exam" tabindex="0" target="_blank" >CGRC</a>
             <a class="mgmtitem1" href="https://www.isc2.org/Certifications/HCISPP" tooltiptext="(ISC)2 Healthcare Information Security and Privacy Practitioner
 $599 exam" tabindex="0" target="_blank">HCISPP</a>
             <a class="mgmtitem3" href="https://www.isaca.org/credentialing/crisc" tooltiptext="ISACA Certified in Risk and Information Systems Control


### PR DESCRIPTION
ISC2 renamed their CAP certification to CGRC

https://www.isc2.org/Certifications/CGRC/CAP-to-CGRC-FAQ

https://www.isc2.org/Certifications/CGRC