### PR TITLE
(ISC)2 change to ISC2 

### DIFF
--- a/Security-Certification-Roadmap8.html
+++ b/Security-Certification-Roadmap8.html
@@ -989,7 +989,7 @@
                     <div class="spacer10"></div>
                     <div class="spacer"></div>
                     <div class="spacer"></div>
-                    <a class="mgmtitem4" href="https://www.isc2.org/Certifications/CISSP-Concentrations" tooltiptext="(ISC)2 Certified Information Systems Security Professional Concentrations
+                    <a class="mgmtitem4" href="https://www.isc2.org/Certifications/CISSP-Concentrations" tooltiptext="ISC2 Certified Information Systems Security Professional Concentrations
     $599 exam" tabindex="0" target="_blank" >CISSP Concentrations</a>
                     <div class="spacer"></div>
                     <a class="mgmtitem1" href="https://www.pmi.org/certifications/types/program-management-pgmp" tooltiptext="PMI Program Management Professional
@@ -1071,7 +1071,7 @@
                     <div class="spacer"></div>
                     <div class="spacer"></div>
                     <div class="spacer"></div>
-                    <a class="mgmtitem25" href="https://www.isc2.org/Certifications/CISSP" tooltiptext="(ISC)2 Certified Information Systems Security Professional
+                    <a class="mgmtitem25" href="https://www.isc2.org/Certifications/CISSP" tooltiptext="ISC2 Certified Information Systems Security Professional
     $749 exam" tabindex="0" target="_blank" ><b>CISSP</b></a>
                     <div class="spacer"></div>
                     <a class="blueopsitem1" href="https://www.iacis.com/certification/cawfe/" tooltiptext="IACIS Certified Advanced Windows Forensic Examiner
@@ -1328,9 +1328,9 @@
     SANS course recommended" tabindex="0" target="_blank" >GLEG</a>
                     <a class="mgmtitem1" href="https://gaqm.org/certifications/information_systems_security/cissm" tooltiptext="GAQM Certified Information Systems Security Manager
     $170 exam" tabindex="0" target="_blank" >CISSM</a>
-                    <a class="mgmtitem1" href="https://www.isc2.org/Certifications/CAP" tooltiptext="(ISC)2 Certified Authorization Professional
-    $599 exam" tabindex="0" target="_blank" >CAP</a>
-                    <a class="mgmtitem1" href="https://www.isc2.org/Certifications/HCISPP" tooltiptext="(ISC)2 Healthcare Information Security and Privacy Practitioner
+                    <a class="mgmtitem1" href="https://www.isc2.org/Certifications/CGRC" tooltiptext="ISC2 Certified Authorization Professional
+    $599 exam" tabindex="0" target="_blank" >CGRC</a>
+                    <a class="mgmtitem1" href="https://www.isc2.org/Certifications/HCISPP" tooltiptext="ISC2 Healthcare Information Security and Privacy Practitioner
     $599 exam" tabindex="0" target="_blank">HCISPP</a>
                     <a class="mgmtitem3" href="https://www.isaca.org/credentialing/crisc" tooltiptext="ISACA Certified in Risk and Information Systems Control
     $760 exam" tabindex="0" target="_blank" >CRISC</a>
@@ -1486,7 +1486,7 @@
   100% practical. No expiry." tabindex="0" target="_blank">MGRC</a>
                     <div class="spacer"></div>
                     <div class="spacer"></div>
-                    <a class="softwareitem6" href="https://www.isc2.org/Certifications/CSSLP" tooltiptext="(ISC)2 Certified Secure Software Lifecycle Professional
+                    <a class="softwareitem6" href="https://www.isc2.org/Certifications/CSSLP" tooltiptext="ISC2 Certified Secure Software Lifecycle Professional
     $599 exam" tabindex="0" target="_blank" >CSSLP</a>
                     <a class="blueopsitem1" href="https://www.mosse-institute.com/certifications/mth-certified-threat-hunter.html" tooltiptext="Moose Institute Certified Threat Hunter Certification
                     $450 certification programme
@@ -1524,7 +1524,7 @@
                     <a class="iamitem1" href="https://idpro.org/cidpro/" tooltiptext="IDPro Certified Identity Professional
     $700 exam" tabindex="0" target="_blank" >CIDPRO</a>
                     <div class="spacer"></div>
-                    <a class="engineeritem1" href="https://www.isc2.org/Certifications/CCSP" tooltiptext="(ISC)2 Certified Cloud Security Professional
+                    <a class="engineeritem1" href="https://www.isc2.org/Certifications/CCSP" tooltiptext="ISC2 Certified Cloud Security Professional
     $599 exam" tabindex="0" target="_blank" >CCSP</a>
                     <div class="spacer"></div>
                     <div class="spacer"></div>
@@ -2145,7 +2145,7 @@
                     <div class="spacer"></div>
                     <a class="assetitem1" href="https://www.identitymanagementinstitute.org/crfs/" tooltiptext="IMI Certified Red Flag Specialist
     $295 exam" target="_blank">CRFS</a>
-                    <a class="mgmtitem15" href="https://www.isc2.org/Certifications/SSCP" tooltiptext="(ISC)2 Systems Security Certified Practitioner
+                    <a class="mgmtitem15" href="https://www.isc2.org/Certifications/SSCP" tooltiptext="ISC2 Systems Security Certified Practitioner
     $249 exam" tabindex="0" target="_blank" ><b>SSCP</b></a>
                     <a class="blueopsitem1" href="https://www.isaca.org/credentialing/cybersecurity/csx-forensics-analysis-certificate" tooltiptext="ISACA Cybersecurity Packet Analysis Certificate
     $250 exam" tabindex="0" target="_blank" >CSX-PA</a>


### PR DESCRIPTION
In August 2023, (ISC)² changed the name of its accreditation body to ISC2.