### PR TITLE
Update Security-Certification-Roadmap9.html

### DIFF
--- a/Security-Certification-Roadmap9.html
+++ b/Security-Certification-Roadmap9.html
@@ -988,7 +988,7 @@ $1,499 lab" tabindex="0" target="_blank" >OSED</a>
             <div class="spacer10"></div>
             <div class="spacer"></div>
             <div class="spacer"></div>
-            <a class="mgmtitem4" href="https://www.isc2.org/Certifications/CISSP-Concentrations" tooltiptext="(ISC)2 Certified Information Systems Security Professional Concentrations
+            <a class="mgmtitem4" href="https://www.isc2.org/Certifications/CISSP-Concentrations" tooltiptext="ISC2 Certified Information Systems Security Professional Concentrations
 $599 exam" tabindex="0" target="_blank" >CISSP Concentrations</a>
             <div class="spacer"></div>
             <a class="mgmtitem1" href="https://www.pmi.org/certifications/types/program-management-pgmp" tooltiptext="PMI Program Management Professional
@@ -1070,7 +1070,7 @@ SANS course recommended" tabindex="0">GAWN</a>
             <div class="spacer"></div>
             <div class="spacer"></div>
             <div class="spacer"></div>
-            <a class="mgmtitem25" href="https://www.isc2.org/Certifications/CISSP" tooltiptext="(ISC)2 Certified Information Systems Security Professional
+            <a class="mgmtitem25" href="https://www.isc2.org/Certifications/CISSP" tooltiptext="ISC2 Certified Information Systems Security Professional
 $749 exam" tabindex="0" target="_blank" ><b>CISSP</b></a>
             <div class="spacer"></div>
             <a class="blueopsitem1" href="https://www.iacis.com/certification/cawfe/" tooltiptext="IACIS Certified Advanced Windows Forensic Examiner
@@ -1327,9 +1327,9 @@ $949 exam
 SANS course recommended" tabindex="0" target="_blank" >GLEG</a>
             <a class="mgmtitem1" href="https://gaqm.org/certifications/information_systems_security/cissm" tooltiptext="GAQM Certified Information Systems Security Manager
 $170 exam" tabindex="0" target="_blank" >CISSM</a>
-            <a class="mgmtitem1" href="https://www.isc2.org/Certifications/CAP" tooltiptext="(ISC)2 Certified Authorization Professional
-$599 exam" tabindex="0" target="_blank" >CAP</a>
-            <a class="mgmtitem1" href="https://www.isc2.org/Certifications/HCISPP" tooltiptext="(ISC)2 Healthcare Information Security and Privacy Practitioner
+            <a class="mgmtitem1" href="https://www.isc2.org/certifications/cgrc" tooltiptext="ISC2 Certified in Governance, Risk and Compliance
+$599 exam" tabindex="0" target="_blank" >CGRC</a>
+            <a class="mgmtitem1" href="https://www.isc2.org/Certifications/HCISPP" tooltiptext="ISC2 Healthcare Information Security and Privacy Practitioner
 $599 exam" tabindex="0" target="_blank">HCISPP</a>
             <a class="mgmtitem3" href="https://www.isaca.org/credentialing/crisc" tooltiptext="ISACA Certified in Risk and Information Systems Control
 $760 exam" tabindex="0" target="_blank" >CRISC</a>
@@ -1485,7 +1485,7 @@ $450 certification programme
 100% practical. No expiry." tabindex="0" target="_blank">MGRC</a>
             <div class="spacer"></div>
             <div class="spacer"></div>
-            <a class="softwareitem6" href="https://www.isc2.org/Certifications/CSSLP" tooltiptext="(ISC)2 Certified Secure Software Lifecycle Professional
+            <a class="softwareitem6" href="https://www.isc2.org/Certifications/CSSLP" tooltiptext="ISC2 Certified Secure Software Lifecycle Professional
 $599 exam" tabindex="0" target="_blank" >CSSLP</a>
             <a class="blueopsitem1" href="https://www.mosse-institute.com/certifications/mth-certified-threat-hunter.html" tooltiptext="Moose Institute Certified Threat Hunter Certification
             $450 certification programme
@@ -1523,7 +1523,7 @@ $800+ exam" tabindex="0" target="_blank" >NSE 6</a>
             <a class="iamitem1" href="https://idpro.org/cidpro/" tooltiptext="IDPro Certified Identity Professional
 $700 exam" tabindex="0" target="_blank" >CIDPRO</a>
             <div class="spacer"></div>
-            <a class="engineeritem1" href="https://www.isc2.org/Certifications/CCSP" tooltiptext="(ISC)2 Certified Cloud Security Professional
+            <a class="engineeritem1" href="https://www.isc2.org/Certifications/CCSP" tooltiptext="ISC2 Certified Cloud Security Professional
 $599 exam" tabindex="0" target="_blank" >CCSP</a>
             <div class="spacer"></div>
             <div class="spacer"></div>
@@ -2144,7 +2144,7 @@ $750 three exams" tabindex="0" target="_blank" >CSX-T</a>
             <div class="spacer"></div>
             <a class="assetitem1" href="https://www.identitymanagementinstitute.org/crfs/" tooltiptext="IMI Certified Red Flag Specialist
 $295 exam" target="_blank">CRFS</a>
-            <a class="mgmtitem15" href="https://www.isc2.org/Certifications/SSCP" tooltiptext="(ISC)2 Systems Security Certified Practitioner
+            <a class="mgmtitem15" href="https://www.isc2.org/Certifications/SSCP" tooltiptext="ISC2 Systems Security Certified Practitioner
 $249 exam" tabindex="0" target="_blank" ><b>SSCP</b></a>
             <a class="blueopsitem1" href="https://www.isaca.org/credentialing/cybersecurity/csx-forensics-analysis-certificate" tooltiptext="ISACA Cybersecurity Packet Analysis Certificate
 $250 exam" tabindex="0" target="_blank" >CSX-PA</a>


### PR DESCRIPTION
On August 17, 2023, the International Information System Security Certification Consortium changed its organizational abbreviation from (ISC)2 to ISC2. In addition, the Certified Authorization Professional (CAP) in ISC2 changed the name of the exam and certification to Certified in Governance, Risk and Compliance (CGRC) effective February 15, 2023.
(JPN)2023年8月17日に、International Information System Security Certification Consortiumは、(ISC)2からISC2に組織の略称を変更しました。また、ISC2のCertified Authorization Professional(CAP)は、2023年2月15日からCertified in Governance, Risk and Compliance(CGRC)に試験及び資格の名称を変更しました。