### PR TITLE
I recommend replacing the eCRE (eLearning Certified Reverse Engineer) with the PJMR (Practical Junior Malware Researcher)

### DIFF
--- a/Security-Certification-Roadmap9.html
+++ b/Security-Certification-Roadmap9.html
@@ -1290,8 +1290,8 @@ Being redesigned" tabindex="0" target="_blank" >S-EHE</a>
             <div class="spacer"></div>
             <div class="spacer"></div>
             <div class="spacer"></div>
-            <a class="redopsitem1" href=" https://elearnsecurity.com/product/ecre-certification/" tooltipright="eLearnSecurity Certified Reverse Engineer
-$400 lab" tabindex="0" target="_blank" >eCRE</a>
+            <a class="redopsitem1" href="https://certifications.tcm-sec.com/pjmr/" tooltipright="Practical Junior Malware Researcher
+$399 lab" tabindex="0" target="_blank" >PJMR</a>
             <!-- Row 12 -->
             <div class="spacer"></div>
             <a class="networkitem1" href="https://www.juniper.net/us/en/training/certification/certification-tracks/junos-security-track/?tab=jncip-sec" tooltipleft="Juniper Networks Certified Internet Professional, Security


### PR DESCRIPTION
I recommend replacing the eCRE (eLearning Certified Reverse Engineer) with the PJMR (Practical Junior Malware Researcher) in the intermediate to expert range of the exploitation section. The link to the eCRE certification is no longer active, and there does not appear to be a new link for this certification. Additionally, the PJMR fits well in this section, aligning well with the other certifications listed below and above in the beginner to expert range.