### PR TITLE
Update Security-Certification-Roadmap9.html Spelling error

### DIFF
--- a/Security-Certification-Roadmap9.html
+++ b/Security-Certification-Roadmap9.html
@@ -1380,7 +1380,7 @@
                     <div class="spacer"></div>
                     <a class="mgmtitem2" href="https://www.axelos.com/certifications/itil-certifications/itil-managing-professional-itil-4" tooltiptext="ITIL Managing Professional
     $9,600 4 course exams
-    4 branded courses requires" tabindex="0" target="_blank" >ITIL MP</a>
+    4 branded courses required" tabindex="0" target="_blank" >ITIL MP</a>
                     <a class="mgmtitem1" href="https://www.scrum.org/scaled-professional-scrum-certification" tooltiptext="Scrum Scaled Professional Scrum
     $250 exam" tabindex="0" target="_blank" >Scrum SPS</a>
                     <a class="mgmtitem1" href="https://www.giac.org/certification/law-data-security-investigations-gleg" tooltiptext="GIAC Law of Data Security &amp; Investigations


### PR DESCRIPTION
4 branded courses requires changed to 4 branded courses required, following standard English conventions and the conventions of this roadmap