### PR TITLE
Fixed Misspelling and Incorrect name in Security-Certification-Roadma…

### DIFF
--- a/Security-Certification-Roadmap9.html
+++ b/Security-Certification-Roadmap9.html
@@ -1486,7 +1486,7 @@
     $1299 exam
     SANS course recommended" tabindex="0" target="_blank" >GX-FA</a>
                     <div class="spacer"></div>
-                    <a class="blueopsitem2" href="https://www.giac.org/certification/gcih" tooltiptext="GIAC Certified Forensics Analystr
+                    <a class="blueopsitem2" href="https://www.giac.org/certification/gcih" tooltiptext="GIAC Certified Incident Handler
     $979 exam
     SANS course recommended" tabindex="0" target="_blank" >GCIH</a>
                     <a class="redopsitem1" href="https://www.giac.org/certifications/experienced-penetration-tester-gxpt/" tooltiptext="GIAC Experienced Penetration Tester


### PR DESCRIPTION
…p9.html

Changed the GCIH (which is the GIAC Certified Incident Handler Certification) tooltip from "GIAC Certified Forensic Analystr" (misspelled and also the incorrect name) to "GIAC Certified Incident Handler"