### PR TITLE
Update MS-100 to MS-102

### DIFF
--- a/Security-Certification-Roadmap9.html
+++ b/Security-Certification-Roadmap9.html
@@ -1431,7 +1431,7 @@
     ~$600 exam" tabindex="0" target="_blank" >CCNP Ent</a>
                     <div class="spacer"></div>
                     <a class="engineeritem2" href="https://docs.microsoft.com/en-us/learn/certifications/m365-enterprise-administrator" tooltiptext="Microsoft 365 Certified Enterprise Administrator Expert
-    $165 exam" tabindex="0" target="_blank" >MS-100</a>
+    $165 exam" tabindex="0" target="_blank" >MS-102</a>
                     <a class="engineeritem1" href="https://www.giac.org/certifications/public-cloud-security-gpcs/" tooltiptext="GIAC Public Cloud Security
     $979 exam
     SANS course recommended" tabindex="0" target="_blank" >GPCS</a>


### PR DESCRIPTION
Microsoft updated **MS-100** as the exam for Microsoft 365 Certified: Administrator Expert to **MS-102** a while back:
https://techcommunity.microsoft.com/blog/microsoftlearnblog/evolving-microsoft-365-certifications-help-keep-you-in-sync-with-the-new-era-of-/3719265

Current link to that cert even mentions **MS-102** now: https://learn.microsoft.com/en-us/credentials/certifications/m365-administrator-expert/